### PR TITLE
Update Zambian Currency from ZMK to ZMW

### DIFF
--- a/src/Webpatser/Countries/Models/countries.json
+++ b/src/Webpatser/Countries/Models/countries.json
@@ -3717,7 +3717,7 @@
       "citizenship":"Zambian",
       "country-code":"894",
       "currency":"Zambian kwacha (inv.)",
-      "currency_code":"ZMK",
+      "currency_code":"ZMW",
       "currency_sub_unit":"ngwee (inv.)",
       "full_name":"Republic of Zambia",
       "iso_3166_2":"ZM",


### PR DESCRIPTION
old ZMK is now obsolete

http://www.xe.com/currency/zmk-zambian-kwacha
