### PR TITLE
Fix for unsigned ID

### DIFF
--- a/src/views/generators/migration.blade.php
+++ b/src/views/generators/migration.blade.php
@@ -12,7 +12,7 @@ class SetupCountriesTable extends Migration {
 		// Creates the users table
 		Schema::create(\Config::get('countries.table_name'), function($table)
 		{		    
-		    $table->integer('id')->index();
+		    $table->integer('id')->unsigned()->index();
 		    $table->string('capital', 255)->nullable();
 		    $table->string('citizenship', 255)->nullable();
 		    $table->string('country_code', 3)->default('');


### PR DESCRIPTION
Some databases (namely PostGres and MariaDB) require the types of foreign and linked primary keys to be the same type. If one is `unsigned` and the other isn't, then the database will throw an issue (see #30). This sets the ID to `unsigned` which is required as per the [Laravel 5 documentation] (https://laravel.com/docs/5.0/schema#foreign-keys).