### PR TITLE
Fix for non-countable variable

### DIFF
--- a/src/Webpatser/Countries/Countries.php
+++ b/src/Webpatser/Countries/Countries.php
@@ -40,7 +40,7 @@ class Countries extends Model {
     protected function getCountries()
     {
         //Get the countries from the JSON file
-        if (sizeof($this->countries) == 0){
+        if (null === $this->countries || sizeof($this->countries) === 0) {
             $this->countries = json_decode(file_get_contents(__DIR__ . '/Models/countries.json'), true);
         }
 


### PR DESCRIPTION
sizeof(): Parameter must be an array or an object that implements Countable {"exception":"[object] (ErrorException(code: 0): sizeof(): Parameter must be an array or an object that implements Countable at /vendor/webpatser/laravel-countries/src/Webpatser/Countries/Countries.php:43)

It was throwing error above.