### PR TITLE
Countries::countries initialized as an empty array

### DIFF
--- a/src/Webpatser/Countries/Countries.php
+++ b/src/Webpatser/Countries/Countries.php
@@ -11,10 +11,10 @@ use Illuminate\Database\Eloquent\Model;
 class Countries extends Model {
 
 	/**
-	 * @var string
-	 * Path to the directory containing countries data.
+	 * @var array
+	 * Array containing countries data from JSON file.
 	 */
-	protected $countries;
+	protected $countries = [];
 
 	/**
 	 * @var string


### PR DESCRIPTION
* fix sizeof() error with php-7.2.1
* fix misleading comment about path

The php error:
In Countries.php line 43:
                                                                               
  sizeof(): Parameter must be an array or an object that implements Countable