### PR TITLE
Allow publish assets (flags images)

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,12 @@ Now add the alias.
     ]
     
 
+Publish the public assets:
+
+```
+    php artisan vendor:publish --provider='Webpatser\\Countries\\CountriesServiceProvider' --tag=assets
+```
+
 ## Model
 
 You can start by publishing the configuration. This is an optional step, it contains the table name and does not need to be altered. If the default name `countries` suits you, leave it. Otherwise run the following command

--- a/src/Webpatser/Countries/CountriesServiceProvider.php
+++ b/src/Webpatser/Countries/CountriesServiceProvider.php
@@ -27,6 +27,10 @@ class CountriesServiceProvider extends ServiceProvider {
         // The publication files to publish
         $this->publishes([__DIR__ . '/../../config/config.php' => config_path('countries.php')]);
 
+        $this->publishes([
+            __DIR__ . '/../../flags' => public_path('vendor/countries/flags'),
+        ], 'assets');
+
         // Append the country settings
         $this->mergeConfigFrom(
             __DIR__ . '/../../config/config.php', 'countries'


### PR DESCRIPTION
Now, when execute the vendor:publish command, your flags images will be copied to the public location.