### PR TITLE
Remove deprecated Optimize call in Laravel 5.6

### DIFF
--- a/src/commands/MigrationCommand.php
+++ b/src/commands/MigrationCommand.php
@@ -53,10 +53,6 @@ class MigrationCommand extends Command {
             {
                 $this->line('');
 
-                $this->call('optimize', []);
-
-                $this->line('');
-
                 $this->info( "Migration successfully created!" );
             }
             else{


### PR DESCRIPTION
Simple delete of the optimize call. 

[https://laravel-news.com/laravel-5-6-removes-artisan-optimize](https://laravel-news.com/laravel-5-6-removes-artisan-optimize)

Referenced in issue #95 

