### PR TITLE
fix override Eloquent model constructor

### DIFF
--- a/src/Webpatser/Countries/Countries.php
+++ b/src/Webpatser/Countries/Countries.php
@@ -26,8 +26,9 @@ class Countries extends Model {
      *
      * @return void
      */
-    public function __construct()
+    public function __construct(array $attributes = [])
     {
+        parent::__construct($attributes);
         $this->table = \Config::get('countries.table_name');
     }
     


### PR DESCRIPTION
This will cause error when we use

```php
$factory->define(\Webpatser\Countries\Countries::class, function (Faker $faker) {
    return [
        'id'                => 458,
        'capital'           => 'Kuala Lumpur (MY1)',
        'citizenship'       => 'Malaysian',
        'country_code'      => 458,
        'currency'          => 'ringgit (inv.)',
        'currency_code'     => 'MYR',
        'currency_sub_unit' => 'sen (inv.)',
        'currency_decimals' => '2',
        'full_name'         => 'Malaysia',
        'iso_3166_2'        => 'MY',
        'iso_3166_3'        => 'MYS',
        'name'              => 'Malaysia',
        'region_code'       => '142',
        'sub_region_code'   => '035',
        'eea'               => 0,
        'calling_code'      => '60',
        'currency_symbol'   => 'RM',
        'flag'              => 'MY.png',
    ];
});

$country = factory(\Webpatser\Countries\Countries::class)->create();
dd($country);
```

The result will have missing attributes

```php
Webpatser\Countries\Countries^ {#1014
  #countries: []
  #table: "countries"
  #connection: "mysql"
  #primaryKey: "id"
  #keyType: "int"
  +incrementing: true
  #with: []
  #withCount: []
  #perPage: 15
  +exists: true
  +wasRecentlyCreated: true
  #attributes: array:1 [
    "id" => 0
  ]
  #original: array:1 [
    "id" => 0
  ]
  #changes: []
  #casts: []
  #classCastCache: []
  #dates: []
  #dateFormat: null
  #appends: []
  #dispatchesEvents: []
  #observables: []
  #relations: []
  #touches: []
  +timestamps: true
  #hidden: []
  #visible: []
  #fillable: []
  #guarded: array:1 [
    0 => "*"
  ]
}
```