### PR TITLE
Republic of Cape Verde -> Republic of Cabo Verde

### DIFF
--- a/src/Webpatser/Countries/Models/countries.json
+++ b/src/Webpatser/Countries/Models/countries.json
@@ -709,7 +709,7 @@
       "currency":"Cape Verde escudo",
       "currency_code":"CVE",
       "currency_sub_unit":"centavo",
-      "full_name":"Republic of Cape Verde",
+      "full_name":"Republic of Cabo Verde",
       "iso_3166_2":"CV",
       "iso_3166_3":"CPV",
       "name":"Cape Verde",


### PR DESCRIPTION
Republic of Cabo Verde adopted as state title in 2014. Common name stays Cape Verde though.