### PR TITLE
SQLite databases can not run the migrations

### DIFF
--- a/src/views/generators/char_migration.blade.php
+++ b/src/views/generators/char_migration.blade.php
@@ -11,11 +11,25 @@ class CharifyCountriesTable extends Migration {
 	{
             Schema::table(\Config::get('countries.table_name'), function($table)
             {
-                DB::statement("ALTER TABLE " . DB::getTablePrefix() . \Config::get('countries.table_name') . " MODIFY country_code CHAR(3) NOT NULL DEFAULT ''");
-                DB::statement("ALTER TABLE " . DB::getTablePrefix() . \Config::get('countries.table_name') . " MODIFY iso_3166_2 CHAR(2) NOT NULL DEFAULT ''");
-                DB::statement("ALTER TABLE " . DB::getTablePrefix() . \Config::get('countries.table_name') . " MODIFY iso_3166_3 CHAR(3) NOT NULL DEFAULT ''");
-                DB::statement("ALTER TABLE " . DB::getTablePrefix() . \Config::get('countries.table_name') . " MODIFY region_code CHAR(3) NOT NULL DEFAULT ''");
-                DB::statement("ALTER TABLE " . DB::getTablePrefix() . \Config::get('countries.table_name') . " MODIFY sub_region_code CHAR(3) NOT NULL DEFAULT ''");
+                $table->char('country_code', 3)
+                    ->default('')
+                    ->change();
+
+                $table->char('iso_3166_2', 2)
+                    ->default('')
+                    ->change();
+
+                $table->char('iso_3166_3', 3)
+                    ->default('')
+                    ->change();
+
+                $table->char('region_code', 3)
+                    ->default('')
+                    ->change();
+
+                $table->char('sub_region_code', 3)
+                    ->default('')
+                    ->change();
             });
         }
 	/**
@@ -27,11 +41,25 @@ class CharifyCountriesTable extends Migration {
 	{
             Schema::table(\Config::get('countries.table_name'), function($table)
             {
-                DB::statement("ALTER TABLE " . DB::getTablePrefix() . \Config::get('countries.table_name') . " MODIFY country_code VARCHAR(3) NOT NULL DEFAULT ''");
-                DB::statement("ALTER TABLE " . DB::getTablePrefix() . \Config::get('countries.table_name') . " MODIFY iso_3166_2 VARCHAR(2) NOT NULL DEFAULT ''");
-                DB::statement("ALTER TABLE " . DB::getTablePrefix() . \Config::get('countries.table_name') . " MODIFY iso_3166_3 VARCHAR(3) NOT NULL DEFAULT ''");
-                DB::statement("ALTER TABLE " . DB::getTablePrefix() . \Config::get('countries.table_name') . " MODIFY region_code VARCHAR(3) NOT NULL DEFAULT ''");
-                DB::statement("ALTER TABLE " . DB::getTablePrefix() . \Config::get('countries.table_name') . " MODIFY sub_region_code VARCHAR(3) NOT NULL DEFAULT ''");
+                $table->string('country_code', 3)
+                    ->default('')
+                    ->change();
+
+                $table->string('iso_3166_2', 2)
+                    ->default('')
+                    ->change();
+
+                $table->string('iso_3166_3', 3)
+                    ->default('')
+                    ->change();
+
+                $table->string('region_code', 3)
+                    ->default('')
+                    ->change();
+
+                $table->string('sub_region_code', 3)
+                    ->default('')
+                    ->change();
             });
 	}
 


### PR DESCRIPTION
As per https://www.techonthenet.com/sqlite/tables/alter_table.php#:~:text=You%20can%20not%20use%20the,data%20into%20the%20new%20table. SQLite Databases lack the support of using statements like ALTER TABLE therefore it is not possible to run the ``{date}_charify_countries_table` migrations on these setups.

Who even uses SQLite you may ask. Well if you think of automated tests it can be quite helpful to quickly setup a database using SQLite.

Using this PR the changes can be adapted even in such setups.