### PR TITLE
Fix: Increase calling_code column length to prevent truncation error

### DIFF
--- a/stubs/migration.blade.php
+++ b/stubs/migration.blade.php
@@ -21,7 +21,7 @@ class SetupCountriesTable extends Migration {
 		    $table->string('currency_code', 3)->nullable();
 		    $table->string('currency_name', 255)->nullable();
 		    $table->string('currency_symbol', 10)->nullable();
-		    $table->string('calling_code', 10)->nullable();
+		    $table->string('calling_code', 30)->nullable();
 		    $table->string('region', 50)->nullable();
 		    $table->json('languages')->nullable();
 		    $table->string('flag', 10)->nullable();


### PR DESCRIPTION
Fixes SQL truncation error during database seeding by increasing the calling_code column length from 10 to 30 characters.

The previous limit of 10 characters was insufficient for countries with multiple calling codes (e.g., Dominican Republic: "1-809, 1-829, 1-849" at 22 characters). The new limit of 30 characters accommodates all current 
calling codes with room for future additions.

Error fixed (#143): 
SQLSTATE[22001]: String data, right truncated: 1406 Data too long for column 'calling_code' at row 1