### PR TITLE
Missing Spain languages

### DIFF
--- a/src/Models/countries.json
+++ b/src/Models/countries.json
@@ -1048,7 +1048,11 @@
     "calling_code": "34",
     "region": "europe",
     "languages": [
-      "es"
+      "es",
+      "ca",
+      "gl",
+      "eu",
+      "oc"
     ],
     "flag": "🇪🇸"
   },


### PR DESCRIPTION
Adding missing Spain co-official languages (ca, gl, eu, and oc)